### PR TITLE
Scatterplot updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@weng-lab/psychscreen-ui-components",
   "description": "Typescript and Material UI based components used for psychSCREEN",
   "author": "SCREEN Team @ UMass Chan Medical School",
-  "version": "2.0.11",
+  "version": "2.0.12",
   "license": "MIT",
   "type": "module",
   "typings": "dist/index.d.ts",

--- a/src/components/ScatterPlot/ScatterPlot.stories.tsx
+++ b/src/components/ScatterPlot/ScatterPlot.stories.tsx
@@ -60,11 +60,12 @@ export const Default: Story = {
         loading: false,
         miniMap: miniMap,
         leftAxisLable: "Y-Axis Label",
-        bottomAxisLabel: "X-Axis Label"
+        bottomAxisLabel: "X-Axis Label",
+        disableTooltip: true
     }
 };
 
-// Default story with scatter data
+// Default story with tooltip
 export const CustomTooltip: Story = {
     args: {
         width: 500,
@@ -93,7 +94,8 @@ export const WithoutMiniMap: Story = {
         pointData: scatterData,
         loading: false,
         leftAxisLable: "Y-Axis Label",
-        bottomAxisLabel: "X-Axis Label"
+        bottomAxisLabel: "X-Axis Label",
+        disableTooltip: true
     }
 };
 
@@ -112,7 +114,8 @@ export const SelectablePoints: Story = {
         loading: false,
         miniMap: miniMap,
         leftAxisLable: "Y-Axis Label",
-        bottomAxisLabel: "X-Axis Label"
+        bottomAxisLabel: "X-Axis Label",
+        disableTooltip: true
     }
 };
 
@@ -142,7 +145,8 @@ export const HoverMultiplePoints: Story = {
         loading: false,
         miniMap: miniMap,
         leftAxisLable: "Y-Axis Label",
-        bottomAxisLabel: "X-Axis Label"
+        bottomAxisLabel: "X-Axis Label",
+        disableTooltip: true
     }
 };
 
@@ -155,7 +159,8 @@ export const OtherShapes: Story = {
         loading: false,
         miniMap: miniMap,
         leftAxisLable: "Y-Axis Label",
-        bottomAxisLabel: "X-Axis Label"
+        bottomAxisLabel: "X-Axis Label",
+        disableTooltip: true
     }
 };
 
@@ -169,7 +174,8 @@ export const ZoomDisabled: Story = {
         miniMap: miniMap,
         leftAxisLable: "Y-Axis Label",
         bottomAxisLabel: "X-Axis Label",
-        disableZoom: true
+        disableZoom: true,
+        disableTooltip: true
     }
 };
 
@@ -190,6 +196,7 @@ export const ZoomDisabledButSelectable: Story = {
                 `You Seleted Points: ${JSON.stringify(selectedPoints)}`
             );
         },
+        disableTooltip: true
     }
 };
 
@@ -210,5 +217,6 @@ export const ControlsPositioning: Story = {
                 `You Seleted Points: ${JSON.stringify(selectedPoints)}`
             );
         },
+        disableTooltip: true
     }
 };

--- a/src/components/ScatterPlot/ScatterPlot.stories.tsx
+++ b/src/components/ScatterPlot/ScatterPlot.stories.tsx
@@ -47,7 +47,6 @@ const shapeData: Point[] = [
 
 // Mock for the map prop
 const miniMap: MiniMapProps = {
-    show: true,
     defaultOpen: true,
     position: { right: 50, bottom: 50 }
 };
@@ -55,8 +54,8 @@ const miniMap: MiniMapProps = {
 // Default story with scatter data
 export const Default: Story = {
     args: {
-        width: 400,
-        height: 400,
+        width: 500,
+        height: 500,
         pointData: scatterData,
         loading: false,
         miniMap: miniMap,
@@ -68,8 +67,8 @@ export const Default: Story = {
 // Default story with scatter data
 export const CustomTooltip: Story = {
     args: {
-        width: 400,
-        height: 400,
+        width: 500,
+        height: 500,
         pointData: scatterData,
         loading: false,
         miniMap: miniMap,
@@ -89,11 +88,10 @@ export const CustomTooltip: Story = {
 // Default story with no mini map
 export const WithoutMiniMap: Story = {
     args: {
-        width: 400,
-        height: 400,
+        width: 500,
+        height: 500,
         pointData: scatterData,
         loading: false,
-        miniMap: { show: false },
         leftAxisLable: "Y-Axis Label",
         bottomAxisLabel: "X-Axis Label"
     }
@@ -102,8 +100,8 @@ export const WithoutMiniMap: Story = {
 // Default story with selectable points
 export const SelectablePoints: Story = {
     args: {
-        width: 400,
-        height: 400,
+        width: 500,
+        height: 500,
         selectable: true,
         onSelectionChange: (selectedPoints) => {
             window.alert(
@@ -121,8 +119,8 @@ export const SelectablePoints: Story = {
 // Default story with clickable points
 // export const ClickablePoints: Story = {
 //     args: {
-//         width: 400,
-//         height: 400,
+//         width: 500,
+//         height: 500,
 //         onPointClicked: (point) => {
 //             console.log('Clicked Point:', point);
 //         },
@@ -137,8 +135,8 @@ export const SelectablePoints: Story = {
 // Default story with grouped points
 export const HoverMultiplePoints: Story = {
     args: {
-        width: 400,
-        height: 400,
+        width: 500,
+        height: 500,
         groupPointsAnchor: "color",
         pointData: moreScatterData,
         loading: false,
@@ -151,12 +149,66 @@ export const HoverMultiplePoints: Story = {
 // Default story with multiple shapes
 export const OtherShapes: Story = {
     args: {
-        width: 400,
-        height: 400,
+        width: 500,
+        height: 500,
         pointData: shapeData,
         loading: false,
         miniMap: miniMap,
         leftAxisLable: "Y-Axis Label",
         bottomAxisLabel: "X-Axis Label"
+    }
+};
+
+// Default story with disabled zoom
+export const ZoomDisabled: Story = {
+    args: {
+        width: 500,
+        height: 500,
+        pointData: scatterData,
+        loading: false,
+        miniMap: miniMap,
+        leftAxisLable: "Y-Axis Label",
+        bottomAxisLabel: "X-Axis Label",
+        disableZoom: true
+    }
+};
+
+// Default story with disabled zoom but selectable
+export const ZoomDisabledButSelectable: Story = {
+    args: {
+        width: 500,
+        height: 500,
+        pointData: scatterData,
+        loading: false,
+        miniMap: miniMap,
+        leftAxisLable: "Y-Axis Label",
+        bottomAxisLabel: "X-Axis Label",
+        disableZoom: true,
+        selectable: true,
+        onSelectionChange: (selectedPoints) => {
+            window.alert(
+                `You Seleted Points: ${JSON.stringify(selectedPoints)}`
+            );
+        },
+    }
+};
+
+// Controls Positioning
+export const ControlsPositioning: Story = {
+    args: {
+        controlsPosition: "bottom",
+        width: 500,
+        height: 500,
+        pointData: scatterData,
+        loading: false,
+        miniMap: miniMap,
+        leftAxisLable: "Y-Axis Label",
+        bottomAxisLabel: "X-Axis Label",
+        selectable: true,
+        onSelectionChange: (selectedPoints) => {
+            window.alert(
+                `You Seleted Points: ${JSON.stringify(selectedPoints)}`
+            );
+        },
     }
 };

--- a/src/components/ScatterPlot/controls.tsx
+++ b/src/components/ScatterPlot/controls.tsx
@@ -1,7 +1,7 @@
 import { useEffect } from "react";
 import { ControlButtonsProps } from "./types";
-import { Button, IconButton, Stack, Tooltip } from "@mui/material";
-import { ZoomIn, ZoomOut, PanTool, Edit } from "@mui/icons-material"
+import { IconButton, Stack, Tooltip } from "@mui/material";
+import { ZoomIn, ZoomOut, PanTool, Edit, SettingsBackupRestore } from "@mui/icons-material"
 
 const ControlButtons = ({
     selectable,
@@ -10,7 +10,8 @@ const ControlButtons = ({
     selectMode,
     zoomIn,
     zoomOut,
-    zoomReset
+    zoomReset,
+    position
 }: ControlButtonsProps) => {
 
     useEffect(() => {
@@ -40,7 +41,7 @@ const ControlButtons = ({
       }, [handleSelectionModeChange]);
       
     return (
-        <Stack direction="column" spacing={5} alignItems={"center"} justifyContent={"center"}>
+        <Stack direction={position === "bottom" ? "row" : "column"} spacing={5} alignItems={"center"} justifyContent={"center"}>
             {
                 selectable && (
                     <Tooltip title="Drag to select">
@@ -50,11 +51,15 @@ const ControlButtons = ({
                     </Tooltip>
                 )
             }
+            {
+                selectable && (
             <Tooltip title="Drag to pan, or hold Shift and drag">
                 <IconButton aria-label="pan" onClick={() => handleSelectionModeChange('pan')} sx={{ color: selectMode === "pan" ? "primary.main" : "default" }}>
                     <PanTool />
                 </IconButton>
             </Tooltip>
+                )
+            }
             <Tooltip title="Zoom In">
                 <IconButton aria-label="zoom-in" onClick={zoomIn}>
                     <ZoomIn />
@@ -65,9 +70,11 @@ const ControlButtons = ({
                     <ZoomOut />
                 </IconButton>
             </Tooltip>
-            <Button sx={{ height: '30px', textTransform: 'none' }} size="small" variant="outlined" onClick={zoomReset} disabled={!resetable}>
-                Reset
-            </Button>
+            <Tooltip title="Reset Zoom and Pan">
+                <IconButton aria-label="resetZoom" onClick={zoomReset} disabled={!resetable}>
+                    <SettingsBackupRestore />
+                </IconButton>
+            </Tooltip>
         </Stack>
     );
 }

--- a/src/components/ScatterPlot/scatterplot.tsx
+++ b/src/components/ScatterPlot/scatterplot.tsx
@@ -61,9 +61,16 @@ const ScatterPlot = <T extends object>(
     const groupedPoints: Point<T>[]  = useMemo(() => {
         const anchor = props.groupPointsAnchor
         if (anchor && hoveredPoint) {
-            return (
-                props.pointData.filter((point) => point[anchor] === hoveredPoint[anchor])
-            )
+            return props.pointData.filter((point) => {
+            if (anchor in point) {
+                // If the anchor is a key of Point<T>, compare directly
+                return point[anchor as keyof Point<T>] === hoveredPoint[anchor as keyof Point<T>];
+            } else if (point.metaData && hoveredPoint.metaData) {
+                // If the anchor is a key of T (metaData), compare inside metaData
+                return point.metaData[anchor as keyof T] === hoveredPoint.metaData[anchor as keyof T];
+            }
+            return false;
+        });
         } else if (hoveredPoint) {
             return([hoveredPoint]);
         } else {

--- a/src/components/ScatterPlot/scatterplot.tsx
+++ b/src/components/ScatterPlot/scatterplot.tsx
@@ -44,6 +44,8 @@ const ScatterPlot = <T extends object>(
     const [lines, setLines] = useState<Lines>([]);
     const [selectMode, setSelectMode] = useState<"select" | "pan">(props.selectable ? "select" : "pan");
     const [showMiniMap, setShowMiniMap] = useState<boolean>(props.miniMap?.defaultOpen ? props.miniMap.defaultOpen : false);
+    const [mouseX, setMouseX] = useState(0);
+    const [mouseY, setMouseY] = useState(0);
     const selectable = props.selectable ? props.selectable : false;
     const margin = { top: 20, right: 20, bottom: 70, left: 70 };
     const boundedWidth = Math.min(props.width * 0.9, props.height * 0.9) - margin.left;
@@ -227,6 +229,9 @@ const ScatterPlot = <T extends object>(
                 setTooltipData(null);
                 return;
             }
+
+            setMouseX(event.pageX);
+            setMouseY(event.pageY);
 
             const point = localPoint(event.currentTarget, event);
             if (!point) return;
@@ -557,7 +562,7 @@ const ScatterPlot = <T extends object>(
                             {/* tooltip */}
                             {
                                 tooltipOpen && tooltipData && isHoveredPointWithinBounds && (
-                                    <VisTooltip left={xScaleTransformed(tooltipData.x) + 200} top={yScaleTransformed(tooltipData.y)}>
+                                    <VisTooltip left={(mouseX + 10)} top={(mouseY)}>
                                         <ScatterTooltip
                                             tooltipBody={props.tooltipBody}
                                             tooltipData={tooltipData}

--- a/src/components/ScatterPlot/scatterplot.tsx
+++ b/src/components/ScatterPlot/scatterplot.tsx
@@ -561,7 +561,7 @@ const ScatterPlot = <T extends object>(
 
                             {/* tooltip */}
                             {
-                                tooltipOpen && tooltipData && isHoveredPointWithinBounds && (
+                                !props.disableTooltip && tooltipOpen && tooltipData && isHoveredPointWithinBounds && (
                                     <VisTooltip left={(mouseX + 10)} top={(mouseY)}>
                                         <ScatterTooltip
                                             tooltipBody={props.tooltipBody}

--- a/src/components/ScatterPlot/types.ts
+++ b/src/components/ScatterPlot/types.ts
@@ -40,7 +40,7 @@ export type ChartProps<T> = {
     onSelectionChange?: (selectedPoints: Point<T>[]) => void;
     //returns a point when clicked on (optional)
     onPointClicked?: (point: Point<T>) => void;
-    groupPointsAnchor?: keyof Point<T>;
+    groupPointsAnchor?: keyof Point<T> | keyof T;
     //custom tooltip formating (optional)
     tooltipBody?: (point: Point<T>) => JSX.Element;
     miniMap?: MiniMapProps;

--- a/src/components/ScatterPlot/types.ts
+++ b/src/components/ScatterPlot/types.ts
@@ -35,6 +35,7 @@ export type ChartProps<T> = {
     loading: boolean;
     selectable?: boolean;
     disableZoom?: boolean;
+    disableTooltip?: boolean;
     controlsPosition?: "left" | "bottom" | "right";
     //returns an array of selected points inside a lasso (optional)
     onSelectionChange?: (selectedPoints: Point<T>[]) => void;

--- a/src/components/ScatterPlot/types.ts
+++ b/src/components/ScatterPlot/types.ts
@@ -20,7 +20,6 @@ export type Point<T> = {
     If not position or reference is given, it will default to the bottom right corner of the screen if shown
 */
 export type MiniMapProps = {
-    show: boolean;
     defaultOpen?: boolean;
     position?: { right: number; bottom: number };
     ref?: MutableRefObject<HTMLDivElement | null>;
@@ -35,6 +34,8 @@ export type ChartProps<T> = {
     pointData: Point<T>[];
     loading: boolean;
     selectable?: boolean;
+    disableZoom?: boolean;
+    controlsPosition?: "left" | "bottom" | "right";
     //returns an array of selected points inside a lasso (optional)
     onSelectionChange?: (selectedPoints: Point<T>[]) => void;
     //returns a point when clicked on (optional)
@@ -42,7 +43,7 @@ export type ChartProps<T> = {
     groupPointsAnchor?: keyof Point<T>;
     //custom tooltip formating (optional)
     tooltipBody?: (point: Point<T>) => JSX.Element;
-    miniMap: MiniMapProps;
+    miniMap?: MiniMapProps;
     leftAxisLable: string;
     bottomAxisLabel: string;
 };
@@ -73,4 +74,5 @@ export type ControlButtonsProps = {
     zoomIn: () => void;
     zoomOut: () => void;
     zoomReset: () => void;
+    position?: "left" | "bottom" | "right";
 }


### PR DESCRIPTION
- fixed tooltip position (still weird on the story docs)
- pan control hidden if selectable is false bc it woulkd be the only control
- icon button for zoom reset
- control position props
- minimap type changes
- disable zoom prop
- groupedPoints anchor changed to include keys of metadata (T)