### PR TITLE
Scatterplot touch ups

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@weng-lab/psychscreen-ui-components",
   "description": "Typescript and Material UI based components used for psychSCREEN",
   "author": "SCREEN Team @ UMass Chan Medical School",
-  "version": "2.0.12",
+  "version": "2.0.13",
   "license": "MIT",
   "type": "module",
   "typings": "dist/index.d.ts",

--- a/src/components/ScatterPlot/controls.tsx
+++ b/src/components/ScatterPlot/controls.tsx
@@ -17,14 +17,14 @@ const ControlButtons = ({
     useEffect(() => {
         // Function to handle key press
         const handleKeyDown = (e: KeyboardEvent) => {
-          if (e.key === 'Shift') {
+          if (e.key === 'Shift' && selectable) {
             handleSelectionModeChange('pan'); // Switch to pan mode when Shift is pressed
           }
         };
     
         // Function to handle key release
         const handleKeyUp = (e: KeyboardEvent) => {
-          if (e.key === 'Shift') {
+          if (e.key === 'Shift' && selectable) {
             handleSelectionModeChange('select'); // Switch back to select mode when Shift is released
           }
         };
@@ -38,7 +38,7 @@ const ControlButtons = ({
           window.removeEventListener('keydown', handleKeyDown);
           window.removeEventListener('keyup', handleKeyUp);
         };
-      }, [handleSelectionModeChange]);
+      }, [handleSelectionModeChange, selectable]);
       
     return (
         <Stack direction={position === "bottom" ? "row" : "column"} spacing={5} alignItems={"center"} justifyContent={"center"}>

--- a/src/components/ScatterPlot/scatterplot.tsx
+++ b/src/components/ScatterPlot/scatterplot.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useMemo, useState } from 'react';
 import CircularProgress from '@mui/material/CircularProgress';
 import { Zoom as VisxZoom } from '@visx/zoom'
 import { ZoomProps } from '@visx/zoom/lib/Zoom'
-import { ChartProps, Line, Lines, Point } from './types';
+import { ChartProps, Line, Lines, Point, ZoomType } from './types';
 import { Tooltip as VisxTooltip } from '@visx/tooltip';
 import { TooltipProps } from '@visx/tooltip/lib/tooltips/Tooltip';
 import { Group } from '@visx/group';
@@ -19,6 +19,7 @@ import { Box, IconButton, Stack, Tooltip } from '@mui/material';
 import { ScaleLinear } from '@visx/vendor/d3-scale';
 import { HighlightAlt } from "@mui/icons-material"
 import MiniMap from './minimap';
+import { HandlerArgs } from '@visx/drag/lib/useDrag';
 
 const initialTransformMatrix = {
     scaleX: 1,
@@ -131,8 +132,8 @@ const ScatterPlot = <T extends object>(
 
     // Setup dragging for lasso drawing
     const onDragStart = useCallback(
-        (currDrag) => {
-            if (selectMode === "select") {
+        (currDrag: HandlerArgs) => {
+            if (selectMode === "select" && currDrag?.x !== undefined && currDrag?.y !== undefined) {
                 // add the new line with the starting point
                 const adjustedX = (currDrag.x - margin.left);
                 const adjustedY = (currDrag.y - margin.top);
@@ -143,8 +144,8 @@ const ScatterPlot = <T extends object>(
     );
 
     const onDragMove = useCallback(
-        (currDrag) => {
-            if (selectMode === "select") {
+        (currDrag: HandlerArgs) => {
+            if (selectMode === "select" && currDrag?.x !== undefined && currDrag?.y !== undefined) {
                 // add the new point to the current line
                 const adjustedX = (currDrag.x - margin.left);
                 const adjustedY = (currDrag.y - margin.top);
@@ -178,7 +179,7 @@ const ScatterPlot = <T extends object>(
     };
 
     const onDragEnd = useCallback(
-        (zoom) => {
+        (zoom: ZoomType) => {
             if (selectMode === "select") {
                 if (lines.length === 0) return;
 
@@ -223,7 +224,7 @@ const ScatterPlot = <T extends object>(
 
     //find the closest point to cursor within threshold to show the tooltip
     const handleMouseMove = useCallback(
-        (event: React.MouseEvent<SVGElement>, zoom) => {
+        (event: React.MouseEvent<SVGElement>, zoom: ZoomType) => {
             if (isDragging || zoom.isDragging) {
                 setTooltipOpen(false);
                 setTooltipData(null);
@@ -365,7 +366,7 @@ const ScatterPlot = <T extends object>(
         </Text>
     );
 
-    if (props.loading || !props.pointData) {
+    if (props.loading || !props.pointData) { 
         return <CircularProgress />;
     }
 

--- a/src/components/ScatterPlot/scatterplot.tsx
+++ b/src/components/ScatterPlot/scatterplot.tsx
@@ -3,7 +3,7 @@ import CircularProgress from '@mui/material/CircularProgress';
 import { Zoom as VisxZoom } from '@visx/zoom'
 import { ZoomProps } from '@visx/zoom/lib/Zoom'
 import { ChartProps, Line, Lines, Point, ZoomType } from './types';
-import { Tooltip as VisxTooltip } from '@visx/tooltip';
+import { Tooltip as VisxTooltip, Portal } from '@visx/tooltip';
 import { TooltipProps } from '@visx/tooltip/lib/tooltips/Tooltip';
 import { Group } from '@visx/group';
 import { scaleLinear } from '@visx/scale';
@@ -231,14 +231,8 @@ const ScatterPlot = <T extends object>(
                 return;
             }
 
-            if (props.ref?.current) {
-                const rect = props.ref.current.getBoundingClientRect();
-                setMouseX(event.clientX - rect.left);
-                setMouseY(event.clientY - rect.top); 
-            } else {
-                setMouseX(event.pageX);
-                setMouseY(event.pageY);
-            }
+            setMouseX(event.pageX);
+            setMouseY(event.pageY);
 
             const point = localPoint(event.currentTarget, event);
             if (!point) return;
@@ -268,7 +262,7 @@ const ScatterPlot = <T extends object>(
                 setTooltipData(null);
                 setTooltipOpen(false);
             }
-        }, [isDragging, props.ref, props.pointData, margin.left, margin.top, xScale, yScale]
+        }, [isDragging, props.pointData, margin.left, margin.top, xScale, yScale]
     );
 
 
@@ -580,12 +574,14 @@ const ScatterPlot = <T extends object>(
                             {/* tooltip */}
                             {
                                 !props.disableTooltip && tooltipOpen && tooltipData && isHoveredPointWithinBounds && (
-                                    <VisTooltip left={(mouseX + 10)} top={(mouseY)}>
-                                        <ScatterTooltip
-                                            tooltipBody={props.tooltipBody}
-                                            tooltipData={tooltipData}
-                                        />
-                                    </VisTooltip>
+                                    <Portal>
+                                        <VisTooltip left={(mouseX + 10)} top={(mouseY)}>
+                                            <ScatterTooltip
+                                                tooltipBody={props.tooltipBody}
+                                                tooltipData={tooltipData}
+                                            />
+                                        </VisTooltip>
+                                    </Portal>
                                 )
                             }
                         </>

--- a/src/components/ScatterPlot/types.ts
+++ b/src/components/ScatterPlot/types.ts
@@ -22,7 +22,6 @@ export type Point<T> = {
 export type MiniMapProps = {
     defaultOpen?: boolean;
     position?: { right: number; bottom: number };
-    ref?: MutableRefObject<HTMLDivElement | null>;
 };
 
 /*
@@ -47,6 +46,7 @@ export type ChartProps<T> = {
     miniMap?: MiniMapProps;
     leftAxisLable: string;
     bottomAxisLabel: string;
+    ref?: MutableRefObject<HTMLDivElement | null>;
 };
 
 export type Line = { x: number; y: number }[];

--- a/src/components/ScatterPlot/types.ts
+++ b/src/components/ScatterPlot/types.ts
@@ -23,6 +23,7 @@ export type Point<T> = {
 export type MiniMapProps = {
     defaultOpen?: boolean;
     position?: { right: number; bottom: number };
+    ref?: MutableRefObject<HTMLDivElement | null>;
 };
 
 /*
@@ -47,7 +48,6 @@ export type ChartProps<T> = {
     miniMap?: MiniMapProps;
     leftAxisLable: string;
     bottomAxisLabel: string;
-    ref?: MutableRefObject<HTMLDivElement | null>;
 };
 
 export type Line = { x: number; y: number }[];

--- a/src/components/ScatterPlot/types.ts
+++ b/src/components/ScatterPlot/types.ts
@@ -1,5 +1,6 @@
 import { MutableRefObject } from "react";
 import { ScaleLinear } from '@visx/vendor/d3-scale';
+import { ProvidedZoom } from "@visx/zoom/lib/types";
 
 /*
     All information given to a point on the plot, including its coordinates(x and y), its radius, color, and opacity, and its metadata information
@@ -59,7 +60,7 @@ export type MapProps<T> = {
     pointData: Point<T>[];
     xScale: ScaleLinear<number, number, never>;
     yScale: ScaleLinear<number, number, never>;
-    zoom;
+    zoom: ZoomType;
 }
 
 export type TooltipProps<T> = {
@@ -77,3 +78,20 @@ export type ControlButtonsProps = {
     zoomReset: () => void;
     position?: "left" | "bottom" | "right";
 }
+
+interface TransformMatrix {
+    scaleX: number;
+    scaleY: number;
+    translateX: number;
+    translateY: number;
+    skewX: number;
+    skewY: number;
+}
+
+type ZoomState = {
+    initialTransformMatrix: TransformMatrix;
+    transformMatrix: TransformMatrix;
+    isDragging: boolean;
+};
+
+export type ZoomType = ProvidedZoom<React.ReactElement<unknown, string | React.JSXElementConstructor<unknown>>> & ZoomState


### PR DESCRIPTION
- portal for tooltip renders based on mouse position
- correctly type zoom and drag
- hovered point brought foward
- shift event listner disabled if not selectable