### PR TITLE
Hide cached searches

### DIFF
--- a/src/components/Autocomplete/Autocomplete.tsx
+++ b/src/components/Autocomplete/Autocomplete.tsx
@@ -35,6 +35,7 @@ import {
 const Search: React.FC<GenomeSearchProps> = ({
   queries,
   assembly,
+  showiCREFlag,
   geneLimit,
   snpLimit,
   icreLimit,
@@ -77,7 +78,7 @@ const Search: React.FC<GenomeSearchProps> = ({
     isFetching: ccreFetching,
   } = useQuery({
     queryKey: ["ccres", inputValue],
-    queryFn: () => getCCREs(inputValue, assembly, ccreLimit || 3),
+    queryFn: () => getCCREs(inputValue, assembly, ccreLimit || 3, showiCREFlag || false),
     enabled: false,
   });
 
@@ -142,8 +143,9 @@ const Search: React.FC<GenomeSearchProps> = ({
       );
     }
     if (ccreData && searchCCRE && inputValue.toLowerCase().startsWith("eh")) {
+      console.log(ccreData.data.cCREAutocompleteQuery)
       resultsList.push(
-        ...ccreResultList(ccreData.data.cCREQuery, ccreLimit || 3)
+        ...ccreResultList(ccreData.data.cCREAutocompleteQuery, ccreLimit || 3)
       );
     }
     if (snpData && searchSnp && inputValue.toLowerCase().startsWith("rs")) {

--- a/src/components/Autocomplete/Autocomplete.tsx
+++ b/src/components/Autocomplete/Autocomplete.tsx
@@ -17,7 +17,11 @@ import {
 } from "@mui/material";
 import { Autocomplete } from "@mui/material";
 import { GenomeSearchProps, Result } from "./types";
-import { QueryClient, QueryClientProvider, useQuery } from "@tanstack/react-query";
+import {
+  QueryClient,
+  QueryClientProvider,
+  useQuery,
+} from "@tanstack/react-query";
 
 /**
  * An autocomplete search component for genomic landmarks such as genes, SNPs, ICRs, and CCRs.
@@ -43,13 +47,6 @@ const Search: React.FC<GenomeSearchProps> = ({
   slotProps,
   ...autocompleteProps
 }) => {
-  // Boolean flags for each query
-  const searchGene = queries.includes("Gene");
-  const searchSnp = queries.includes("SNP");
-  const searchICRE = queries.includes("iCRE");
-  const searchCCRE = queries.includes("cCRE");
-  const searchCoordinate = queries.includes("Coordinate");
-
   // State variables
   const [inputValue, setInputValue] = useState("");
   const [selection, setSelection] = useState<Result>({} as Result);
@@ -57,6 +54,12 @@ const Search: React.FC<GenomeSearchProps> = ({
     defaultResults || null
   );
   const [isLoading, setIsLoading] = useState(false);
+
+  const searchGene = queries.includes("Gene");
+  const searchSnp = queries.includes("SNP");
+  const searchICRE = queries.includes("iCRE");
+  const searchCCRE = queries.includes("cCRE");
+  const searchCoordinate = queries.includes("Coordinate");
 
   const {
     data: icreData,
@@ -130,31 +133,43 @@ const Search: React.FC<GenomeSearchProps> = ({
   useEffect(() => {
     if (isLoading) return;
     const resultsList = [];
-    if (geneData) {
+    if (geneData && searchGene) {
       resultsList.push(...geneResultList(geneData.data.gene, geneLimit || 3));
     }
-    if (icreData && inputValue.toLowerCase().startsWith("eh")) {
+    if (icreData && searchICRE && inputValue.toLowerCase().startsWith("eh")) {
       resultsList.push(
         ...icreResultList(icreData.data.iCREQuery, icreLimit || 3)
       );
     }
-    if (ccreData && inputValue.toLowerCase().startsWith("eh")) {
+    if (ccreData && searchCCRE && inputValue.toLowerCase().startsWith("eh")) {
       resultsList.push(
         ...ccreResultList(ccreData.data.cCREQuery, ccreLimit || 3)
       );
     }
-    if (snpData && inputValue.toLowerCase().startsWith("rs")) {
+    if (snpData && searchSnp && inputValue.toLowerCase().startsWith("rs")) {
       resultsList.push(
         ...snpResultList(snpData.data.snpAutocompleteQuery, snpLimit || 3)
       );
     }
-    if (searchCoordinate && isDomain(inputValue)) {
+    if (isDomain(inputValue) && searchCoordinate) {
       resultsList.push(...getCoordinates(inputValue, assembly));
     }
 
     if (resultsList.length === 0) setResults(null);
     else setResults(resultsList);
-  }, [isLoading, icreData, ccreData, geneData, snpData]);
+  }, [
+    isLoading,
+    icreData,
+    ccreData,
+    geneData,
+    snpData,
+    searchGene,
+    searchICRE,
+    searchCCRE,
+    searchSnp,
+    searchCoordinate,
+    inputValue,
+  ]);
 
   // Handle submit
   const onSubmit = useCallback(() => {
@@ -184,10 +199,10 @@ const Search: React.FC<GenomeSearchProps> = ({
   return (
     <Box
       display="flex"
-      flexDirection="row" 
+      flexDirection="row"
       gap={2}
       style={{ ...style }}
-      sx={{ ...sx}}
+      sx={{ ...sx }}
       {...slotProps?.box}
     >
       <Autocomplete
@@ -256,31 +271,32 @@ const Search: React.FC<GenomeSearchProps> = ({
  */
 function renderGroup(params: any, inputValue: string) {
   // Sort items within each group by title match relevance
-  const sortedOptions = Array.isArray(params.children) && !isDomain(inputValue)
-    ? params.children.sort((a: any, b: any) => {
-        const aTitle = (
-          a.props?.children?.props?.children?.[0]?.props?.children || ""
-        ).toLowerCase();
-        const bTitle = (
-          b.props?.children?.props?.children?.[0]?.props?.children || ""
-        ).toLowerCase();
-        const query = inputValue.toLowerCase();
-        // Exact matches first
-        if (aTitle === query && bTitle !== query) return -1;
-        if (bTitle === query && aTitle !== query) return 1;
+  const sortedOptions =
+    Array.isArray(params.children) && !isDomain(inputValue)
+      ? params.children.sort((a: any, b: any) => {
+          const aTitle = (
+            a.props?.children?.props?.children?.[0]?.props?.children || ""
+          ).toLowerCase();
+          const bTitle = (
+            b.props?.children?.props?.children?.[0]?.props?.children || ""
+          ).toLowerCase();
+          const query = inputValue.toLowerCase();
+          // Exact matches first
+          if (aTitle === query && bTitle !== query) return -1;
+          if (bTitle === query && aTitle !== query) return 1;
 
-        // Starts with query second
-        if (aTitle.startsWith(query) && !bTitle.startsWith(query)) return -1;
-        if (bTitle.startsWith(query) && !aTitle.startsWith(query)) return 1;
+          // Starts with query second
+          if (aTitle.startsWith(query) && !bTitle.startsWith(query)) return -1;
+          if (bTitle.startsWith(query) && !aTitle.startsWith(query)) return 1;
 
-        // Contains query third
-        if (aTitle.includes(query) && !bTitle.includes(query)) return -1;
-        if (bTitle.includes(query) && !aTitle.includes(query)) return 1;
+          // Contains query third
+          if (aTitle.includes(query) && !bTitle.includes(query)) return -1;
+          if (bTitle.includes(query) && !aTitle.includes(query)) return 1;
 
-        // Alphabetical order for equal relevance
-        return aTitle.localeCompare(bTitle);
-      })
-    : params.children;
+          // Alphabetical order for equal relevance
+          return aTitle.localeCompare(bTitle);
+        })
+      : params.children;
 
   return (
     <div key={params.key}>

--- a/src/components/Autocomplete/queries.ts
+++ b/src/components/Autocomplete/queries.ts
@@ -1,97 +1,110 @@
 export const SNP_AUTOCOMPLETE_QUERY = `
-    query suggestions($assembly: String!, $snpid: String!) { 
-        snpAutocompleteQuery(assembly: $assembly, snpid: $snpid) {
-            id
-            coordinates {
-                chromosome
-                start
-                end
-            }
-        }
-    }`;
+  query suggestions($assembly: String!, $snpid: String!) { 
+      snpAutocompleteQuery(assembly: $assembly, snpid: $snpid) {
+          id
+          coordinates {
+              chromosome
+              start
+              end
+          }
+      }
+  }
+`;
 
 export const GENE_AUTOCOMPLETE_QUERY = `
-    query Genes(
-        $id: [String]
-        $name: [String]
-        $strand: String
-        $chromosome: String
-        $start: Int
-        $end: Int
-        $gene_type: String
-        $havana_id: String
-        $name_prefix: [String!]
-        $limit: Int
-        $assembly: String!
-    ) {
-        gene(
-            id: $id
-            name: $name
-            strand: $strand
-            chromosome: $chromosome
-            start: $start
-            end: $end
-            gene_type: $gene_type
-            havana_id: $havana_id
-            name_prefix: $name_prefix
-            limit: $limit
-            assembly: $assembly
-            orderby: "name"
-        ) {
-            id
-            name
-            coordinates {
-                chromosome
-                start
-                end
-            }
-        }
-    }
+  query Genes(
+      $id: [String]
+      $name: [String]
+      $strand: String
+      $chromosome: String
+      $start: Int
+      $end: Int
+      $gene_type: String
+      $havana_id: String
+      $name_prefix: [String!]
+      $limit: Int
+      $assembly: String!
+  ) {
+      gene(
+          id: $id
+          name: $name
+          strand: $strand
+          chromosome: $chromosome
+          start: $start
+          end: $end
+          gene_type: $gene_type
+          havana_id: $havana_id
+          name_prefix: $name_prefix
+          limit: $limit
+          assembly: $assembly
+          orderby: "name"
+      ) {
+          id
+          name
+          coordinates {
+              chromosome
+              start
+              end
+          }
+      }
+  }
 `;
 
 export const RESOLVE_QUERY = `
-    query q(
-        $id: String!
-        $assembly: String!
-    ) {
-        resolve(
-            id: $id
-            assembly: $assembly
-        ) {
-            coordinates {
-                chromosome
-                start
-                end
-            }
-        }
-    }`;
+  query q(
+      $id: String!
+      $assembly: String!
+  ) {
+      resolve(
+          id: $id
+          assembly: $assembly
+      ) {
+          coordinates {
+              chromosome
+              start
+              end
+          }
+      }
+  }
+`;
 
 export const ICRE_AUTOCOMPLETE_QUERY = `
-    query iCREQuery($accession_prefix: [String!], $limit: Int) {
-        iCREQuery(accession_prefix: $accession_prefix, limit: $limit) {
-            rdhs
-            accession
-            celltypes
-            coordinates {
-                start
-                end
-                chromosome
-            }
-        }
-    }
+  query iCREQuery($accession_prefix: [String!], $limit: Int) {
+      iCREQuery(accession_prefix: $accession_prefix, limit: $limit) {
+          rdhs
+          accession
+          celltypes
+          coordinates {
+              start
+              end
+              chromosome
+          }
+      }
+  }
 `;
 
 export const CCRE_AUTOCOMPLETE_QUERY = `
-    query cCREQuery($accession_prefix: [String!], $limit: Int, $assembly: String!) {
-        cCREQuery(accession_prefix: $accession_prefix, assembly: $assembly, limit: $limit) {
-            accession
-            coordinates {
-                start
-                end
-                chromosome
-            }
-        }
+  query cCREAutocompleteQuery(
+    $accession_prefix: [String!]
+    $assembly: String!
+    $includeiCREs: Boolean
+    $limit: Int
+  ) {
+    cCREAutocompleteQuery(
+      includeiCREs: $includeiCREs
+      assembly: $assembly
+      limit: $limit
+      accession_prefix: $accession_prefix
+    ) {    
+      accession
+      isiCRE
+      coordinates {
+        chromosome
+        start
+        end
+      }
     }
+  }
 `;
 
 export const getICREs = async (value: string, limit: number) => {
@@ -109,15 +122,21 @@ export const getICREs = async (value: string, limit: number) => {
   return response.json();
 };
 
-export const getCCREs = async (value: string, assembly: string, limit: number) => {
+export const getCCREs = async (
+  value: string,
+  assembly: string,
+  limit: number,
+  showiCREFlag: boolean
+) => {
   const response = await fetch("https://screen.api.wenglab.org/graphql", {
     method: "POST",
     body: JSON.stringify({
-      query: CCRE_AUTOCOMPLETE_QUERY, 
+      query: CCRE_AUTOCOMPLETE_QUERY,
       variables: {
         accession_prefix: [value],
         assembly: assembly.toLowerCase(),
         limit: limit,
+        includeiCREs: showiCREFlag
       },
     }),
     headers: { "Content-Type": "application/json" },
@@ -125,7 +144,11 @@ export const getCCREs = async (value: string, assembly: string, limit: number) =
   return response.json();
 };
 
-export const getGenes = async (value: string, assembly: string, limit: number) => {
+export const getGenes = async (
+  value: string,
+  assembly: string,
+  limit: number
+) => {
   const response = await fetch("https://screen.api.wenglab.org/graphql", {
     method: "POST",
     body: JSON.stringify({
@@ -142,7 +165,11 @@ export const getGenes = async (value: string, assembly: string, limit: number) =
   return response.json();
 };
 
-export const getSNPs = async (value: string, assembly: string, limit: number) => {
+export const getSNPs = async (
+  value: string,
+  assembly: string,
+  limit: number
+) => {
   const response = await fetch("https://screen.api.wenglab.org/graphql", {
     method: "POST",
     body: JSON.stringify({

--- a/src/components/Autocomplete/types.ts
+++ b/src/components/Autocomplete/types.ts
@@ -5,7 +5,7 @@ export type GenomeSearchProps = Partial<AutocompleteProps<Result, false, true, f
     assembly: "GRCh38" | "mm10";
     onSearchSubmit: (result: Result) => void;
     defaultResults?: Result[];
-
+    showiCREFlag?: boolean;
     // queries
     queries: ResultType[];
     geneLimit?: number;
@@ -81,4 +81,5 @@ export interface CCREResponse {
     accession: string;
     coordinates: Domain
     celltypes: string[]
+    isiCRE: boolean
 }

--- a/src/components/Autocomplete/utils.ts
+++ b/src/components/Autocomplete/utils.ts
@@ -131,7 +131,7 @@ export function ccreResultList(
   return formatResults(results, limit, {
     getTitle: (result) => result.accession,
     getDescription: (result) =>
-      `${result.coordinates.chromosome}:${result.coordinates.start}-${result.coordinates.end}`,
+      `${result.coordinates.chromosome}:${result.coordinates.start}-${result.coordinates.end}${result.isiCRE ? ", iCRE" : ""}`,
     type: "cCRE",
   });
 }

--- a/src/test.tsx
+++ b/src/test.tsx
@@ -1,59 +1,28 @@
 import { createRoot } from "react-dom/client";
-import { Stack } from "@mui/material";
-import { MiniMapProps, ScatterPlot } from "./components/ScatterPlot";
+import { Box, Typography } from "@mui/material";
+import { GenomeSearch, ResultType } from "./components/Autocomplete";
 import { useEffect, useState } from "react";
 
-type Point = {
-  x: number;
-  y: number;
-  color: string;
-  shape: "circle" | "triangle";
-};
-
-// Example data for the scatter plot
-const scatterData: Point[] = [
-  { x: 1, y: 2, color: 'red', shape: "circle" },
-  { x: 3, y: 4, color: 'blue', shape: "circle" },
-  { x: 5, y: 6, color: 'green', shape: "circle" },
-];
-
-// Mock for the map prop
-const miniMap: MiniMapProps = {
-  position: { right: 50, bottom: 50 }
-};
-
 function App() {
-  const [isLoading, setIsLoading] = useState(true);
-
-useEffect(() => {
-    const fakeLoading = setTimeout(() => {
-        setIsLoading(false);
-    }, 2000); // Adjust delay as needed
-
-    return () => clearTimeout(fakeLoading); // Cleanup on unmount
-}, []);
-
+  const [query, setQuery] = useState<ResultType[]>(["Gene"]);
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setQuery(["SNP"]);
+    }, 5000);
+    return () => clearTimeout(timer);
+  }, []);
   return (
-    <Stack height={"57vh"} width={"70vw"} padding={1} sx={{ border: '2px solid', borderColor: 'grey.400', borderRadius: '8px' }}>
-      <ScatterPlot
-        pointData={scatterData}
-        loading={isLoading}
-        leftAxisLabel="sdgc"
-        bottomAxisLabel="s.khdcvsvb"
-        miniMap={miniMap}
-        disableTooltip
-        initialState={
-          {
-            minimap: {
-              open: true,
-            },
-            controls: {
-              selectionType: "pan"
-            }
-          }
-        }
+    <Box display="flex" flexDirection="column" justifyContent="center" alignItems="center" height="50vh" width="100%">
+      <Typography variant="h1">{query.join(", ")}</Typography>
+      <GenomeSearch
+        assembly="GRCh38"
+        queries={query}
+        onSearchSubmit={(result) => {
+          console.log(result);
+        }}
+        sx={{ width: "400px" }}
       />
-    </Stack>
+    </Box>
   );
 }
 

--- a/src/test.tsx
+++ b/src/test.tsx
@@ -1,27 +1,31 @@
 import { createRoot } from "react-dom/client";
 import { Box, Typography } from "@mui/material";
-import { GenomeSearch, ResultType } from "./components/Autocomplete";
-import { useEffect, useState } from "react";
+import { GenomeSearch, Result, ResultType } from "./components/Autocomplete";
+import { useState } from "react";
 
 function App() {
-  const [query, setQuery] = useState<ResultType[]>(["Gene"]);
-  useEffect(() => {
-    const timer = setTimeout(() => {
-      setQuery(["SNP"]);
-    }, 5000);
-    return () => clearTimeout(timer);
-  }, []);
+  const query: ResultType[] = ["cCRE"]
+  const [result, setResult] = useState<Result>()
   return (
-    <Box display="flex" flexDirection="column" justifyContent="center" alignItems="center" height="50vh" width="100%">
-      <Typography variant="h1">{query.join(", ")}</Typography>
+    <Box display="flex" flexDirection="column" justifyContent="start" alignItems="center" height="100vh" width="100%">
+      <Typography variant="h2">{query.join(", ")}</Typography>
       <GenomeSearch
         assembly="GRCh38"
         queries={query}
+        showiCREFlag
         onSearchSubmit={(result) => {
-          console.log(result);
+          setResult(result)
         }}
         sx={{ width: "400px" }}
       />
+      {result && (
+        <>
+          <Typography variant="h3">{result.type}</Typography>
+          <Typography variant="h3">{result?.title}</Typography>
+          <Typography variant="h4">{result?.description}</Typography>
+          <Typography variant="h5">{result?.domain.chromosome}:{result?.domain.start}-{result?.domain.end}</Typography>
+        </>
+      )}
     </Box>
   );
 }


### PR DESCRIPTION
When the query prop changes, old cached search results still show as their data is not null, so the check passes. Now also checks if the query is allowed which will hide cached results.